### PR TITLE
EID-418 - Fix to pass in the correct variables to the Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 .gradle/
 .settings/
 .project
+.idea/
+verify-eidas-trust-anchor.iml

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchor.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchor.java
@@ -31,8 +31,8 @@ public class CountryTrustAnchor {
     if (publicKey == null) {
       throw new RuntimeException(String.format(
         "Certificate public key in wrong format, got %s, expecting %s",
-        RSAPublicKey.class.getName(),
-        certificate.getPublicKey().getClass().getName()));
+        certificate.getPublicKey().getClass().getName(),
+        RSAPublicKey.class.getName()));
     }
 
     Base64 base64cert = Base64.encode(certificate.getEncoded());


### PR DESCRIPTION
- Variables were being passed into the exception the wrong way round.

Co-authored-by: hugh emerson <hugh.emerson@digital.cabinet-office.gov.uk>