### PR TITLE
EID-403: Add test for unreadable input files on signing command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ dependencies {
             'uk.gov.ida:security-utils:2.0.0-317'
 
     testCompile 'uk.gov.ida:ida-dev-pki:1.1.0-20',
-                'org.junit.jupiter:junit-jupiter-api:5.0.0'
+                'org.junit.jupiter:junit-jupiter-api:5.0.0',
+                'org.mockito:mockito-core:2.+'
 
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0',
                 'org.junit.platform:junit-platform-launcher:1.0.1'

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Signer.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Signer.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.eidas.trustanchor.cli;
+
+import com.nimbusds.jose.JOSEException;
+import uk.gov.ida.eidas.trustanchor.Generator;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Signer {
+  private PrivateKey key;
+  private X509Certificate certificate;
+  private List<File> inputFiles;
+  private File outputFile;
+
+  Signer(PrivateKey key, X509Certificate certificate, List<File> inputFiles, File outputFile) {
+    this.key = key;
+    this.certificate = certificate;
+    this.inputFiles = inputFiles;
+    this.outputFile = outputFile;
+  }
+
+  public Void sign() throws IOException, JOSEException, ParseException, CertificateEncodingException {
+    Collection<String> nonReadable = inputFiles.stream()
+        .filter(f -> !f.canRead())
+        .map(File::getPath)
+        .collect(Collectors.toList());
+
+    if (!nonReadable.isEmpty()) {
+      String missingFiles = String.join(", ", nonReadable);
+      throw new FileNotFoundException("Could not read files: " + missingFiles);
+    }
+
+    if (outputFile != null && !(outputFile.canWrite() || (!outputFile.exists() && outputFile.getAbsoluteFile().getParentFile().canWrite()))) {
+      throw new FileNotFoundException("Cannot write to output file: " + outputFile.getAbsolutePath());
+    }
+
+    List<String> inputs = new ArrayList<>(inputFiles.size());
+    for (File input : inputFiles) {
+      inputs.add(new String(Files.readAllBytes(input.toPath())));
+    }
+    final Generator generator = new Generator(key, certificate);
+    final String generatedAnchors = generator.generate(inputs).serialize();
+
+    final OutputStreamWriter output = (outputFile == null ? new OutputStreamWriter(System.out) : new FileWriter(outputFile));
+    output.write(generatedAnchors);
+    output.close();
+
+    return null;
+  }
+}

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/cli/SigningCommand.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/cli/SigningCommand.java
@@ -1,21 +1,12 @@
 package uk.gov.ida.eidas.trustanchor.cli;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.OutputStreamWriter;
-import java.nio.file.Files;
+import java.io.*;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-import uk.gov.ida.eidas.trustanchor.Generator;
 
 abstract class SigningCommand {
   @Parameters(description = "The JSON Web Key (JWK) files to extract certificates from")
@@ -25,31 +16,6 @@ abstract class SigningCommand {
   private File outputFile;
 
   public Void build(PrivateKey key, X509Certificate certificate) throws Exception {
-    Collection<String> nonReadable = inputFiles.stream()
-        .filter(f -> !f.canRead())
-        .map(File::getPath)
-        .collect(Collectors.toList());
-      
-    if (!nonReadable.isEmpty()) {
-      String missingFiles = String.join(", ", nonReadable);
-      throw new FileNotFoundException("Could not read files: " + missingFiles);
-    }
-
-    if (outputFile != null && !(outputFile.canWrite() || (!outputFile.exists() && outputFile.getAbsoluteFile().getParentFile().canWrite()))) {
-      throw new FileNotFoundException("Cannot write to output file: " + outputFile.getAbsolutePath());
-    }
-
-    List<String> inputs = new ArrayList<>(inputFiles.size());
-    for (File input : inputFiles) {
-      inputs.add(new String(Files.readAllBytes(input.toPath())));
-    }
-    final Generator generator = new Generator(key, certificate);
-    final String generatedAnchors = generator.generate(inputs).serialize();
-
-    final OutputStreamWriter output = (outputFile == null ? new OutputStreamWriter(System.out) : new FileWriter(outputFile));
-    output.write(generatedAnchors);
-    output.close();
-
-    return null;
+    return new Signer(key, certificate, this.inputFiles, this.outputFile).sign();
   }
 }

--- a/src/test/java/uk/gov/ida/eidas/trustanchor/cli/SignerTest.java
+++ b/src/test/java/uk/gov/ida/eidas/trustanchor/cli/SignerTest.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.eidas.trustanchor.cli;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SignerTest {
+
+    @Test
+    public void testSignerThrowsExceptionWhenInputFileNotReadable() throws Exception {
+
+        PrivateKey key = mock(PrivateKey.class);
+        X509Certificate certificate = mock(X509Certificate.class);
+        
+        File inputFile = mock(File.class);
+        when(inputFile.getPath()).thenReturn("test");
+        when(inputFile.canRead()).thenReturn(false);
+        List<File> inputFiles = ImmutableList.of(inputFile);
+
+        File outputFile = mock(File.class);
+
+        Signer signer = new Signer(key, certificate, inputFiles, outputFile);
+
+        Assertions.assertThrows(FileNotFoundException.class, signer::sign);
+    }
+}


### PR DESCRIPTION
-Extract SigningCommand logic into separate humble object
-Add test for failure case of unreadable input files
-Add dependencies on mockito