### PR TITLE
Build on travis / publish to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+matrix:
+  allow_failures:
+  - jdk: oraclejdk9

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Verify eIDAS Trust Anchor Generator
 ===================================
+
+[![Build Status](https://travis-ci.org/alphagov/verify-eidas-trust-anchor.svg?branch=master)](https://travis-ci.org/alphagov/verify-eidas-trust-anchor)
+
 [European identity schemes](https://ec.europa.eu/digital-single-market/en/e-identification) each have unique metadata containing their identity providers and public keys. Every metadata file is signed with a country-specific key which allows metadata consumers to trust its authenticity.
 
 We collect certificates for connected European countries into one place and sign them all together with a Verify key.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ buildscript {
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             jcenter()
+            maven { url "https://dl.bintray.com/alphagov/maven-test" }
+            maven { url "https://dl.bintray.com/robfletcher/gradle-plugins" }
         }
         else {
             maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
@@ -9,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.gradle.plugins:gradle-compass:1.0.7',
-                'uk.gov.ida:ida-gradle:1.1.0-15',
+                'uk.gov.ida:ida-gradle:1.1.0-23',
                 'com.github.ben-manes:gradle-versions-plugin:0.11.3',
                 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ buildscript {
     }
 }
 
+plugins { id "com.jfrog.bintray" version "1.8.0" }
+
 apply plugin: 'java'
 apply plugin: 'idaJar'
 apply plugin: 'jacoco'
@@ -19,10 +21,18 @@ apply plugin: 'maven-publish'
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 mainClassName = 'uk.gov.ida.eidas.trustanchor.cli.Application'
-version = "1.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+def buildVersion = "1.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+version = "$buildVersion"
 
 repositories {
-    maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
+    if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+        logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+        maven { url  'https://dl.bintray.com/alphagov/maven-test' }
+        jcenter()
+    }
+    else {
+        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
+    }
 }
 
 dependencies {
@@ -31,9 +41,9 @@ dependencies {
             'org.json:json:20180130',
             'com.google.guava:guava:23.1-jre'
 
-    testCompile 'uk.gov.ida:ida-dev-pki:1.1.0-28',
+    testCompile 'uk.gov.ida:ida-dev-pki:1.1.0-32',
             'org.junit.jupiter:junit-jupiter-api:5.0.0',
-            'uk.gov.ida:security-utils:2.0.0-317',
+            'uk.gov.ida:security-utils:2.0.0-335',
             'org.mockito:mockito-core:2.+',
             'org.assertj:assertj-core:3.9.1'
 
@@ -76,3 +86,21 @@ publishing {
         }
     }
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'verify-eidas-trust-anchor'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-dev-pki.git'
+        version {
+            name = "$buildVersion"
+        }
+    }
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
+        }
     }
     dependencies {
         classpath 'org.gradle.plugins:gradle-compass:1.0.7',


### PR DESCRIPTION
Now that we're publishing our libraries to Bintray we can build this repository on travis. This will mean a nice README badge and also PR builds.

Also publishes builds of verify-eidas-trust-anchor to bintray so its dependants can have the same treatment.