### PR TITLE
Fix reflection related error when signing with smart card type

### DIFF
--- a/src/main/java/uk/gov/ida/eidas/trustanchor/PKCS11KeyLoader.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/PKCS11KeyLoader.java
@@ -65,7 +65,7 @@ public class PKCS11KeyLoader {
   private static KeyStore getKeyStore(File pkcs11Config, Class<? extends Provider> klazz) throws NoSuchMethodException, SecurityException, InstantiationException,
           IllegalAccessException, IllegalArgumentException, InvocationTargetException, IOException, KeyStoreException {
     final Constructor<? extends Provider> constructor = klazz.getConstructor(String.class);
-    final Provider provider = constructor.newInstance(pkcs11Config);
+    final Provider provider = constructor.newInstance(pkcs11Config.getAbsolutePath());
     provider.load(new FileReader(pkcs11Config));
     Security.addProvider(provider);
     return KeyStore.getInstance("PKCS11", provider);


### PR DESCRIPTION
When we try to generate the trust anchor using a smart card type we noticed that we were getting exception like this:
```
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (uk.gov.ida.eidas.trustanchor.cli.SignWithSmartcard@4e515669): java.lang.IllegalArgumentException: argument type mismatch
	at picocli.CommandLine.execute(CommandLine.java:479)
	at picocli.CommandLine.access$600(CommandLine.java:143)
	at picocli.CommandLine$RunLast.handleParseResult(CommandLine.java:559)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:677)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:630)
	at uk.gov.ida.eidas.trustanchor.cli.Application.main(Application.java:14)
Caused by: java.lang.IllegalArgumentException: argument type mismatch
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at uk.gov.ida.eidas.trustanchor.PKCS11KeyLoader.getKeyStore(PKCS11KeyLoader.java:68)
	at uk.gov.ida.eidas.trustanchor.PKCS11KeyLoader.getSigningKey(PKCS11KeyLoader.java:36)
	at uk.gov.ida.eidas.trustanchor.cli.SignWithSmartcard.call(SignWithSmartcard.java:29)
	at uk.gov.ida.eidas.trustanchor.cli.SignWithSmartcard.call(SignWithSmartcard.java:12)
	at picocli.CommandLine.execute(CommandLine.java:477)
```

This set of changes fix the problem of passing in the wrong argument type to constructor when we are trying to create an instance.