### PR TITLE
BAU: Add command to print out an encoded trust anchor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This tool can:
 * generate trust anchors from a country's certificate
 * aggregate many trust anchors together
 * sign the aggregated anchors into a full signed trust anchor
+* print a full signed trust anchor to show its constituent keys
 
 ## Build
 
@@ -60,10 +61,16 @@ Aggregates and signs a collection of trust anchors by using a smartcard (such as
       --cert "Public Certificate alias" \
       --password 12345
 
-This requires an external native library, such as [OpenSC](https://github.com/opensc/opensc). The config gile will [passed to the PKCS11 provider as configuration](https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#P11Provider). For OpenSC, the correct config file might be:
+This requires an external native library, such as [OpenSC](https://github.com/opensc/opensc). The config file will [passed to the PKCS11 provider as configuration](https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#P11Provider). For OpenSC, the correct config file might be:
 
     library = /usr/local/lib/opensc-pkcs11.so
     name = opensc
+
+### Print
+
+Prints the human-readable JSON representation of each signed trust anchor passed, contained in a JSON array. If no signed trust anchors are passed, an empty array is printed.
+
+    ... print [trust-anchor.jwt [...]]
 
 ## Support and raising issues
 

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Application.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Application.java
@@ -6,6 +6,7 @@ import picocli.CommandLine.RunLast;
 
 @Command(name="tasign", description="Signs trust anchors", subcommands={
   Import.class,
+  Print.class,
   SignWithFile.class,
   SignWithSmartcard.class})
 class Application implements Runnable {

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Print.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/cli/Print.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.eidas.trustanchor.cli;
+
+import com.nimbusds.jose.JWSObject;
+
+import org.json.JSONArray;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@Command(name="print", description="Print a trust anchor file in JSON format")
+class Print implements Callable<Void> {
+
+    @Parameters(arity="0..*", index="0", description="Trust anchor files to load and display.")
+    private List<File> anchors = new ArrayList<>();
+
+    @Option(names={ "-o", "--output" }, description="File to output to. Defaults to stdout.", required=false)
+    private File outputFile;
+
+    @Override
+    public Void call() throws Exception {
+        final int INDENT_FACTOR = 4;
+        JSONArray anchorObjects = new JSONArray();
+
+        for (File anchor : anchors) {
+            String encodedJwsObject = new String(Files.readAllBytes(anchor.toPath()));
+            anchorObjects.put(JWSObject.parse(encodedJwsObject).getPayload().toJSONObject());
+        }
+
+        writeOut(this.outputFile, anchorObjects.toString(INDENT_FACTOR));
+        return null;
+    }
+
+    private void writeOut(File outputFile, String outputString) throws IOException {
+        OutputStreamWriter output = (outputFile == null ? new OutputStreamWriter(System.out) : new FileWriter(outputFile));
+        output.write(outputString);
+        output.close();
+    }
+}


### PR DESCRIPTION
This commit adds a `print` command to the trust anchor tool which accepts zero or more signed trust anchors and prints their human-readable JSON representation to `STDOUT` or a file.

Invoke it thus:
`$ java -jar verify-trust-anchor.jar print trust-anchor.jwt ...`

This is considerably easier than manually splitting the base64-encoded structure into its parts and decoding it manually.