### PR TITLE
EID-941: readded publishing tasks to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,3 +83,43 @@ test {
     }
 }
 
+task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+}
+
+publishing {
+    repositories {
+        maven {
+            url '/srv/maven'
+        }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            groupId = 'uk.gov.ida.eidas'
+            artifactId = 'trust-anchor'
+
+            artifact sourceJar {
+                classifier 'sources'
+            }
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'verify-eidas-trust-anchor'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-eidas-trust-anchor.git'
+        version {
+            name = "$buildVersion"
+        }
+    }
+}


### PR DESCRIPTION
Originally we were going to use dockerhub to run the trustanchor,
but it's not possible to run the app on docker with a smartcard.

Re-adding publishing to artifactory and bintray so we can fetch the jar
in metadata

Co-authored-by: Kerr Rainey <kerr.rainey@digital.cabinet-office.gov.uk>