### PR TITLE
EID-941: Merge service files in shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ test {
 }
 
 shadowJar {
+    mergeServiceFiles()
     classifier = null
 }
 


### PR DESCRIPTION
Adds the ServicesResourceTransformer that will merge all Service
Manifests.
This fixes the problem where OpenSaml Service Initialization isn't able
to read its default configurations.

https://stackoverflow.com/questions/42540485/how-to-stop-maven-shade-plugin-from-blocking-java-util-serviceloader-initializat

Co-authored-by: Kerr Rainey <kerr.rainey@digital.cabinet-office.gov.uk>