### PR TITLE
BAU: Validate keys when we use the Print command.

### DIFF
--- a/src/main/java/uk/gov/ida/eidas/cli/trustanchor/Print.java
+++ b/src/main/java/uk/gov/ida/eidas/cli/trustanchor/Print.java
@@ -1,11 +1,15 @@
 package uk.gov.ida.eidas.cli.trustanchor;
 
 import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
 
 import org.json.JSONArray;
+import net.minidev.json.JSONObject;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import uk.gov.ida.eidas.trustanchor.CountryTrustAnchorValidator;
 import uk.gov.ida.eidas.utils.FileReader;
 
 import java.io.File;
@@ -13,6 +17,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -25,18 +30,34 @@ class Print implements Callable<Void> {
     @Option(names={ "-o", "--output" }, description="File to output to. Defaults to stdout.", required=false)
     private File outputFile;
 
+    private CountryTrustAnchorValidator validator = CountryTrustAnchorValidator.build();
+
     @Override
     public Void call() throws Exception {
         final int INDENT_FACTOR = 4;
         JSONArray anchorObjects = new JSONArray();
+        boolean invalid = false;
 
         for (File anchor : anchors) {
             String encodedJwsObject = FileReader.readFileContent(anchor);
-            anchorObjects.put(JWSObject.parse(encodedJwsObject).getPayload().toJSONObject());
+            JSONObject jws = JWSObject.parse(encodedJwsObject).getPayload().toJSONObject();
+            List<JWK> keys = JWKSet.parse(jws).getKeys();
+            boolean valid = keysAreValid(keys);
+            invalid = invalid || !valid;
+            anchorObjects.put(jws);
         }
 
         writeOut(this.outputFile, anchorObjects.toString(INDENT_FACTOR));
+        if (invalid) throw new RuntimeException("One or more of the JWKs did not pass validation.");
         return null;
+    }
+
+    private boolean keysAreValid(List<JWK> keys) {
+        return keys.stream()
+            .map(validator::findErrors)
+            .flatMap(Collection::stream)
+            .peek(System.err::println)
+            .count() == 0;
     }
 
     private void writeOut(File outputFile, String outputString) throws IOException {

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/InvalidTrustAnchorException.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/InvalidTrustAnchorException.java
@@ -1,0 +1,13 @@
+package uk.gov.ida.eidas.trustanchor;
+
+public class InvalidTrustAnchorException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  public InvalidTrustAnchorException(String message) {
+    super(message);
+  }
+
+  public InvalidTrustAnchorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Now when we use the Print command, we actually pass the country trust anchors themselves through the validator, so we'll get a bad return code and error message if any of them aren't valid.