### PR TITLE
EID-1105: Upgrade to Java 11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,4 @@ language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk8
-matrix:
-  allow_failures:
-  - jdk: oraclejdk9
+  - openjdk11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/src/main/java/uk/gov/ida/eidas/cli/metadata/SignWithSmartcard.java
+++ b/src/main/java/uk/gov/ida/eidas/cli/metadata/SignWithSmartcard.java
@@ -6,6 +6,7 @@ import uk.gov.ida.eidas.utils.keyloader.PKCS11KeyLoader;
 
 import java.io.File;
 import java.security.PrivateKey;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.Callable;
 
@@ -25,7 +26,7 @@ public class SignWithSmartcard extends SignMetadata implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    PKCS11KeyLoader keyLoader = new PKCS11KeyLoader(sun.security.pkcs11.SunPKCS11.class, pkcs11Config, password);
+    PKCS11KeyLoader keyLoader = new PKCS11KeyLoader(Security.getProvider("SunPKCS11").getClass(), pkcs11Config, password);
     PrivateKey key = keyLoader.getSigningKey(keyAlias);
     X509Certificate certificate = keyLoader.getPublicCertificate(certAlias);
     return build(key, certificate, algorithm);

--- a/src/main/java/uk/gov/ida/eidas/cli/trustanchor/SignWithSmartcard.java
+++ b/src/main/java/uk/gov/ida/eidas/cli/trustanchor/SignWithSmartcard.java
@@ -6,6 +6,7 @@ import uk.gov.ida.eidas.utils.keyloader.PKCS11KeyLoader;
 
 import java.io.File;
 import java.security.PrivateKey;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.Callable;
 
@@ -25,7 +26,7 @@ public class SignWithSmartcard extends SignTrustAnchor implements Callable<Void>
 
   @Override
   public Void call() throws Exception {
-    PKCS11KeyLoader keyLoader = new PKCS11KeyLoader(sun.security.pkcs11.SunPKCS11.class, pkcs11Config, password);
+    PKCS11KeyLoader keyLoader = new PKCS11KeyLoader(Security.getProvider("SunPKCS11").getClass(), pkcs11Config, password);
     PrivateKey key = keyLoader.getSigningKey(keyAlias);
     X509Certificate certificate = keyLoader.getPublicCertificate(certAlias);
     return build(key, certificate);


### PR DESCRIPTION
Upgrade the Gradle from 4.10 -> 4.10.2
Migrate from the deprecated `sun.security.pkcs11.SunPKCS11` to using `Security.getProvider("SunPKCS11").getClass()`.