### PR TITLE
BAU Allow creation of trust anchor from invalid certs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
             "uk.gov.ida:saml-serializers:$dependencyVersions.saml_libs_version",
             "uk.gov.ida:saml-security:$dependencyVersions.saml_libs_version"
 
-    testCompile 'uk.gov.ida:ida-dev-pki:1.1.0-32',
+    testCompile 'uk.gov.ida:ida-dev-pki:1.1.0-37',
             'org.junit.jupiter:junit-jupiter-api:5.0.0',
             'uk.gov.ida:security-utils:2.0.0-335',
             'org.mockito:mockito-core:2.+',

--- a/src/main/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchor.java
+++ b/src/main/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchor.java
@@ -22,6 +22,11 @@ import java.util.stream.Collectors;
 public class CountryTrustAnchor {
 
     public static JWK make(List<X509Certificate> certificates, String keyId) {
+        return make(certificates, keyId, true);
+    }
+
+//    This should only be used with `validateKey = false` to generate trust anchors for testing, never for production.
+    public static JWK make(List<X509Certificate> certificates, String keyId, Boolean validateKey) {
 
         if (certificates.isEmpty()) {
             throw new IllegalArgumentException("Certificate list empty");
@@ -40,9 +45,11 @@ public class CountryTrustAnchor {
 
         JWK key = buildJWK(getSupportedKeyType(certificates), keyId, sortedCertificates.get(0), encodedSortedCertChain);
 
-        Collection<String> errors = CountryTrustAnchorValidator.build().findErrors(key);
-        if (!errors.isEmpty()) {
-            throw new IllegalArgumentException(String.format("Managed to generate an invalid anchor: %s", String.join(", ", errors)));
+        if (validateKey) {
+            Collection<String> errors = CountryTrustAnchorValidator.build().findErrors(key);
+            if (!errors.isEmpty()) {
+                throw new IllegalArgumentException(String.format("Managed to generate an invalid anchor: %s", String.join(", ", errors)));
+            }
         }
 
         return key;

--- a/src/test/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchorTest.java
+++ b/src/test/java/uk/gov/ida/eidas/trustanchor/CountryTrustAnchorTest.java
@@ -1,0 +1,51 @@
+package uk.gov.ida.eidas.trustanchor;
+
+import certificates.values.CACertificates;
+import com.nimbusds.jose.jwk.JWK;
+import org.junit.jupiter.api.Test;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class CountryTrustAnchorTest {
+
+    private List<X509Certificate> invalidCertChain = createInvalidCertChain();
+
+    @Test
+    public void makeThrowsExceptionIfIncludesInvalidCertificate() {
+
+        JWK trustAnchorKey = null;
+        try {
+            CountryTrustAnchor.make(invalidCertChain, "key-id");
+            fail("CountryTrustAnchor#make should throw exception for invalid certificate");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).startsWith("Managed to generate an invalid anchor: Certificate CN=IDA Stub Country Signing Dev");
+        }
+
+        assertThat(trustAnchorKey).isNull();
+    }
+
+    @Test
+    public void makeValidationCanBeOverRidden() {
+        JWK trustAnchorKey = CountryTrustAnchor.make(invalidCertChain, "key-id", false);
+
+        assertThat(trustAnchorKey.getKeyID()).isEqualTo("key-id");
+    }
+
+    private List<X509Certificate> createInvalidCertChain() {
+        List<String> certificates = asList(
+            CACertificates.TEST_ROOT_CA,
+            CACertificates.TEST_IDP_CA,
+            TestCertificateStrings.STUB_COUNTRY_PUBLIC_NOT_YET_VALID_CERT
+        );
+        X509CertificateFactory certificateFactory = new X509CertificateFactory();
+        return certificates.stream().map(certificateFactory::createCertificate).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/uk/gov/ida/eidas/trustanchor/GeneratorTest.java
+++ b/src/test/java/uk/gov/ida/eidas/trustanchor/GeneratorTest.java
@@ -155,7 +155,7 @@ public class GeneratorTest {
     @Test
     public void shouldThrowWhenDateOfX509CertificateIsInvalid(){
 
-        String expiredCert = TestCertificateStrings.EXPIRED_SELF_SIGNED_SIGNING_PUBLIC_CERT;
+        String expiredCert = TestCertificateStrings.STUB_COUNTRY_PUBLIC_EXPIRED_CERT;
 
         X509Certificate x509Certificate = new X509CertificateFactory().createCertificate(expiredCert);
         RSAPublicKey rsaPublicKey = (RSAPublicKey) x509Certificate.getPublicKey();


### PR DESCRIPTION
I'm fixing a bug with the MSA where an out of date certificate in the
trust anchor can stop it from starting. As part of the testing of this,
it'd be good to test it with an actual trust anchor that has an out of
date cert in it.

The current way that trust anchors are created will prevent an out of
date cert being used. This commit adds a flag to `make` that allows
validation to be skipped. This should clearly only be used for testing
purposes.