### PR TITLE
BAU Relocate mockito in shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ test {
 }
 
 shadowJar {
+    relocate 'org.mockito', 'shadow.org.mockito'
     mergeServiceFiles()
     classifier = null
 }


### PR DESCRIPTION
The shadow jar includes all the projects dependencies, and that includes
mockito. The trust anchor is a dep of saml-libs, which in turn is a dep
of the matching service adapter.

Due to mockito being included in the shadow jar, the matching service
adapter actually ends up using the trust anchors version of mockito
rather than its own top level dependency. This can break things if those
versions are different.

By relocating the dependency in the shadow jar, we can avoid this
conflict. See [here for more details.](https://imperceptiblethoughts.com/shadow/configuration/relocation)