### PR TITLE
BAU Relocate assertj in shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ test {
 
 shadowJar {
     relocate 'org.mockito', 'shadow.org.mockito'
+    relocate 'org.assertj', 'shadow.org.assertj'
     mergeServiceFiles()
     classifier = null
 }


### PR DESCRIPTION
The version of assertj being used in the trust anchor is clashing with
the version used in the hub. Relocating it, in the same way as Mockito
should prevent this.