### PR TITLE
EID-1254: Sign Proxy Node Metadata

### DIFF
--- a/src/main/java/uk/gov/ida/eidas/cli/Application.java
+++ b/src/main/java/uk/gov/ida/eidas/cli/Application.java
@@ -7,11 +7,13 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import uk.gov.ida.eidas.cli.metadata.ConnectorMetadataSigningApplication;
+import uk.gov.ida.eidas.cli.metadata.ProxyNodeMetadataSigningApplication;
 import uk.gov.ida.eidas.cli.trustanchor.TrustAnchorGenerationApplication;
 
 @Command(name="eidas-trust-tool", description="Generates and Signs eIDAS artifacts", subcommands={
     TrustAnchorGenerationApplication.class,
-    ConnectorMetadataSigningApplication.class
+    ConnectorMetadataSigningApplication.class,
+    ProxyNodeMetadataSigningApplication.class
 })
 public class Application implements Runnable {
     public static void main(String[] args) throws InitializationException {

--- a/src/main/java/uk/gov/ida/eidas/cli/metadata/ProxyNodeMetadataSigningApplication.java
+++ b/src/main/java/uk/gov/ida/eidas/cli/metadata/ProxyNodeMetadataSigningApplication.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.eidas.cli.metadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name="proxy-node-metadata", description="Signs Proxy Node Metadata", subcommands={
+    SignWithFile.class,
+    SignWithSmartcard.class
+})
+public class ProxyNodeMetadataSigningApplication implements Runnable {
+    @Override
+    public void run() {
+        // If we reach this point, we didn't match any subcommands.
+        // So print the usage; there's nothing to do by default.
+        CommandLine.usage(this, System.err);
+    }
+}


### PR DESCRIPTION
verify-metadata calls the trust-anchor library to sign eidas connector metadata.
Added an additional command to sign eidas proxy node metadata.  This reuses the connector metadata code which already signs with an hsm or smartcard.  The additional option makes usage explicit and prevents making any changes to working connector metadata signing.