### PR TITLE
Stop publishing to artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,16 +66,6 @@ test {
 }
 
 publishing {
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
-
     publications {
         mavenJava(MavenPublication) {
             from components.java


### PR DESCRIPTION
Bintray is the source of truth now.

Bintray is made available via whitelisted-repos on artifactory, so we
still pull dependencies down using artifactory, but we only need to
push dependencies to bintray.